### PR TITLE
Fix handling of ranges beyond end of object

### DIFF
--- a/services/s3/itest/s3_test.go
+++ b/services/s3/itest/s3_test.go
@@ -250,6 +250,7 @@ func TestRangeQuery(t *testing.T) {
 		{Name: "Skip entire first part and half of second part", Range: "bytes=8-13", Body: "rld hi"},
 		{Name: "Prefix", Range: "bytes=0-8", Body: "hello wor"},
 		{Name: "Suffix", Range: "bytes=-4", Body: "d hi"},
+		{Name: "Beyond the end of the object", Range: "bytes=0-100", Body: "hello world hi"},
 	}
 
 	for _, testCase := range testCases {

--- a/services/s3/s3.go
+++ b/services/s3/s3.go
@@ -242,7 +242,14 @@ func parseRangeHeader(rangeHeader string, o *Object) ([]ByteRange, *awserrors.Er
 	return result, nil
 }
 
-func (s *S3) readerForRange(object *Object, br ByteRange) (io.Reader, *awserrors.Error) {
+// Returns a reader, a content length, and an error.
+//
+// When given a range that stretches beyond the length of an object, S3 will return the piece of
+// the object that exists, with an appropriate content length.
+//
+// When given a range that is entirely not within the object, S3 will return a 416 error. This is
+// currently not implemented.
+func (s *S3) readerForRange(object *Object, br ByteRange) (io.Reader, int64, *awserrors.Error) {
 	var parts []Part
 	if len(object.Parts) == 0 {
 		parts = []Part{{MD5: object.MD5, Size: object.ContentLength}}
@@ -255,6 +262,7 @@ func (s *S3) readerForRange(object *Object, br ByteRange) (io.Reader, *awserrors
 	bytesUntilStart := br.startByte
 	bytesUntilEnd := br.endByte
 	var readers []io.Reader
+	readLength := int64(0)
 	// Loop over parts in order, updating bytesUntilStart and bytesUntilEnd. If the chunk lies
 	// within the range that must be returned, use a section reader to capture the appropriate range.
 	for _, part := range parts {
@@ -274,7 +282,7 @@ func (s *S3) readerForRange(object *Object, br ByteRange) (io.Reader, *awserrors
 		// Otherwise, open a reader for this chunk.
 		f, err := os.Open(s.filepath(part.MD5))
 		if err != nil {
-			return nil, awserrors.XXX_TODO(err.Error())
+			return nil, 0, awserrors.XXX_TODO(err.Error())
 		}
 		var bytesToReadFromThisChunk int64
 		if bytesUntilEnd >= size {
@@ -287,9 +295,10 @@ func (s *S3) readerForRange(object *Object, br ByteRange) (io.Reader, *awserrors
 
 		readers = append(readers, io.NewSectionReader(f, bytesUntilStart, bytesToReadFromThisChunk))
 		bytesUntilStart = 0
-		bytesUntilEnd -= int64(bytesToReadFromThisChunk)
+		bytesUntilEnd -= bytesToReadFromThisChunk
+		readLength += bytesToReadFromThisChunk
 	}
-	return io.MultiReader(readers...), nil
+	return io.MultiReader(readers...), readLength, nil
 }
 
 func (s *S3) getObject(input GetObjectInput, includeBody bool) (*GetObjectOutput, *awserrors.Error) {
@@ -338,8 +347,8 @@ func (s *S3) getObject(input GetObjectInput, includeBody bool) (*GetObjectOutput
 		var readers []io.Reader
 		totalLength := int64(0)
 		for _, rangeItem := range ranges {
-			totalLength += (rangeItem.endByte - rangeItem.startByte)
-			readerForRange, err := s.readerForRange(object, rangeItem)
+			readerForRange, readLength, err := s.readerForRange(object, rangeItem)
+			totalLength += readLength
 			if err != nil {
 				return nil, err
 			}

--- a/services/s3/types.go
+++ b/services/s3/types.go
@@ -316,3 +316,13 @@ type ListObjectsV2Output struct {
 	Prefix                *string
 	StartAfter            *string
 }
+
+type InvalidRangeError struct {
+	XMLName          xml.Name `xml:"Error"`
+	Code             string
+	Message          string
+	RangeRequested   string
+	ActualObjectSize int64
+	RequestId        string
+	HostId           string
+}


### PR DESCRIPTION
S3 allows fetching a range that exceeds the end of the object, and returns all of the data that exists within the object.