### PR TITLE
Add FIFO queue support to SQS

### DIFF
--- a/main.go
+++ b/main.go
@@ -157,8 +157,8 @@ func main() {
 			}
 			attrs := map[string]string{}
 			if strings.HasSuffix(name, ".fifo") {
-				attrs["FifoQueue"] = "true"
-				attrs["ContentBasedDeduplication"] = "true"
+				attrs[sqs.AttrFifoQueue] = "true"
+				attrs[sqs.AttrContentBasedDeduplication] = "true"
 			}
 			s.CreateQueue(sqs.CreateQueueInput{
 				QueueName:  name,

--- a/main.go
+++ b/main.go
@@ -69,7 +69,7 @@ func main() {
 	s3InitialBuckets := flag.String("s3InitialBuckets", "", "Buckets to create at startup. Example: bucket1,bucket2,bucket3")
 
 	enableSQS := flag.Bool("enableSQS", true, "Enable SQS service")
-	sqsInitialQueues := flag.String("sqsInitialQueues", "", "Queues to create at startup. Example: queue1,queue2,queue3")
+	sqsInitialQueues := flag.String("sqsInitialQueues", "", "Queues to create at startup. Names ending in .fifo are created as FIFO queues with content-based deduplication. Example: queue1,queue2,queue3.fifo")
 
 	flag.Parse()
 
@@ -155,8 +155,14 @@ func main() {
 			if name == "" {
 				continue
 			}
+			attrs := map[string]string{}
+			if strings.HasSuffix(name, ".fifo") {
+				attrs["FifoQueue"] = "true"
+				attrs["ContentBasedDeduplication"] = "true"
+			}
 			s.CreateQueue(sqs.CreateQueueInput{
-				QueueName: name,
+				QueueName:  name,
+				Attributes: attrs,
 			})
 		}
 		// Register JSON handler

--- a/services/sqs/errors.go
+++ b/services/sqs/errors.go
@@ -39,3 +39,7 @@ func InvalidIdFormat(message string) *awserrors.Error {
 func ReceiptHandleIsInvalid(message string) *awserrors.Error {
 	return awserrors.Generate400Exception("ReceiptHandleIsInvalid", message)
 }
+
+func MissingParameter(message string) *awserrors.Error {
+	return awserrors.Generate400Exception("MissingParameter", message)
+}

--- a/services/sqs/handler.go
+++ b/services/sqs/handler.go
@@ -102,7 +102,11 @@ func unmarshal(r *http.Request, target any) error {
 			for i := 1; ; i++ {
 				// TODO(zbarsky): this is pretty HAX way to control the deserialization
 				switch field.Name {
-				case "Attribute", "Tag":
+				// Legacy query-protocol field names ("Attribute", "Tag") and their
+				// current struct names ("Attributes", "Tags"). Modern SDKs use JSON
+				// via RegisterHTTPHandlers; this path can be removed once no
+				// form-urlencoded clients remain.
+				case "Attribute", "Attributes", "Tag", "Tags":
 					mapKey := r.FormValue(fmt.Sprintf("%s.%d.Key", fieldSingular, i))
 					mapValue := r.FormValue(fmt.Sprintf("%s.%d.Value", fieldSingular, i))
 					if mapKey == "" && mapValue == "" {

--- a/services/sqs/itest/sqs_test.go
+++ b/services/sqs/itest/sqs_test.go
@@ -3,10 +3,12 @@ package itest
 import (
 	"bytes"
 	"context"
+	"errors"
 	"log/slog"
 	"net"
 	"net/http"
 	"slices"
+	"strings"
 	"testing"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
@@ -130,61 +132,6 @@ func TestSendReceiveMessage_RoundtripAttributes(t *testing.T) {
 			msg.MessageAttributes["binaryList"].BinaryListValues,
 			messageAttributes["binaryList"].BinaryListValues,
 		)
-	}
-}
-
-func TestReceiveMessageOutput_MultipleMessages(t *testing.T) {
-	ctx := context.Background()
-	client, srv := makeClientServerPair()
-	defer srv.Shutdown(ctx)
-
-	resp, err := client.CreateQueue(ctx, &sqs.CreateQueueInput{
-		QueueName: aws.String("queue"),
-	})
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	bodies := []string{"message-1", "message-2", "message-3"}
-	for _, body := range bodies {
-		_, err = client.SendMessage(ctx, &sqs.SendMessageInput{
-			QueueUrl:    resp.QueueUrl,
-			MessageBody: aws.String(body),
-		})
-		if err != nil {
-			t.Fatal(err)
-		}
-	}
-
-	receiveResp, err := client.ReceiveMessage(ctx, &sqs.ReceiveMessageInput{
-		QueueUrl:            resp.QueueUrl,
-		MaxNumberOfMessages: 10,
-	})
-	if err != nil {
-		t.Fatal(err)
-	}
-	if len(receiveResp.Messages) != 3 {
-		t.Fatalf("Expected 3 messages, got %d", len(receiveResp.Messages))
-	}
-
-	var receivedBodies []string
-	for _, msg := range receiveResp.Messages {
-		if msg.Body == nil {
-			t.Fatal("Message body should not be nil")
-		}
-		if msg.MessageId == nil || *msg.MessageId == "" {
-			t.Fatal("Message should have a MessageId")
-		}
-		if msg.ReceiptHandle == nil || *msg.ReceiptHandle == "" {
-			t.Fatal("Message should have a ReceiptHandle")
-		}
-		receivedBodies = append(receivedBodies, *msg.Body)
-	}
-
-	slices.Sort(receivedBodies)
-	slices.Sort(bodies)
-	if !slices.Equal(receivedBodies, bodies) {
-		t.Fatalf("Expected bodies %v, got %v", bodies, receivedBodies)
 	}
 }
 
@@ -315,5 +262,325 @@ func TestInitialQueues(t *testing.T) {
 	}
 	if *receiveResp.Messages[0].Body != body {
 		t.Fatalf("Expected body %q, got %q", body, *receiveResp.Messages[0].Body)
+	}
+}
+
+func createFifoQueue(t *testing.T, ctx context.Context, client *sqs.Client, name string) string {
+	t.Helper()
+	resp, err := client.CreateQueue(ctx, &sqs.CreateQueueInput{
+		QueueName: aws.String(name),
+		Attributes: map[string]string{
+			"FifoQueue":                 "true",
+			"ContentBasedDeduplication": "true",
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	return *resp.QueueUrl
+}
+
+// createFifoQueueNoDedup creates a FIFO queue without content-based dedup, so
+// the caller must supply an explicit MessageDeduplicationId.
+func createFifoQueueNoDedup(t *testing.T, ctx context.Context, client *sqs.Client, name string) string {
+	t.Helper()
+	resp, err := client.CreateQueue(ctx, &sqs.CreateQueueInput{
+		QueueName: aws.String(name),
+		Attributes: map[string]string{
+			"FifoQueue": "true",
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	return *resp.QueueUrl
+}
+
+func TestFifoQueue_CreateWithSuffix(t *testing.T) {
+	ctx := context.Background()
+	client, srv := makeClientServerPair()
+	defer srv.Shutdown(ctx)
+
+	queueUrl := createFifoQueue(t, ctx, client, "test-queue.fifo")
+
+	listResp, err := client.ListQueues(ctx, &sqs.ListQueuesInput{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(listResp.QueueUrls) != 1 {
+		t.Fatalf("Expected 1 queue, got %d", len(listResp.QueueUrls))
+	}
+	if listResp.QueueUrls[0] != queueUrl {
+		t.Fatalf("Queue URL mismatch: %s != %s", listResp.QueueUrls[0], queueUrl)
+	}
+}
+
+// isErrorCode reports whether err is an AWS API error with the given code and,
+// if msgSubstr is non-empty, a message containing it (to disambiguate
+// same-code errors).
+func isErrorCode(err error, code, msgSubstr string) bool {
+	var apiErr interface {
+		ErrorCode() string
+		ErrorMessage() string
+	}
+	return errors.As(err, &apiErr) &&
+		apiErr.ErrorCode() == code &&
+		strings.Contains(apiErr.ErrorMessage(), msgSubstr)
+}
+
+// TestFifoQueue_Validation covers FIFO input-validation error paths.
+func TestFifoQueue_Validation(t *testing.T) {
+	ctx := context.Background()
+	client, srv := makeClientServerPair()
+	defer srv.Shutdown(ctx)
+
+	t.Run("RequiresMessageGroupId", func(t *testing.T) {
+		queueUrl := createFifoQueue(t, ctx, client, "needs-group-id.fifo")
+		_, err := client.SendMessage(ctx, &sqs.SendMessageInput{
+			QueueUrl:    aws.String(queueUrl),
+			MessageBody: aws.String("body"),
+		})
+		if !isErrorCode(err, "MissingParameter", "MessageGroupId") {
+			t.Fatalf("Expected MissingParameter error naming MessageGroupId, got %v", err)
+		}
+	})
+
+	t.Run("RequiresDeduplicationId", func(t *testing.T) {
+		queueUrl := createFifoQueueNoDedup(t, ctx, client, "needs-dedup-id.fifo")
+		_, err := client.SendMessage(ctx, &sqs.SendMessageInput{
+			QueueUrl:       aws.String(queueUrl),
+			MessageBody:    aws.String("body"),
+			MessageGroupId: aws.String("group1"),
+		})
+		if !isErrorCode(err, "MissingParameter", "MessageDeduplicationId") {
+			t.Fatalf("Expected MissingParameter error naming MessageDeduplicationId, got %v", err)
+		}
+	})
+
+	t.Run("RejectsFifoAttributeWithoutSuffix", func(t *testing.T) {
+		_, err := client.CreateQueue(ctx, &sqs.CreateQueueInput{
+			QueueName: aws.String("not-fifo-named"),
+			Attributes: map[string]string{
+				"FifoQueue": "true",
+			},
+		})
+		if !isErrorCode(err, "ValidationException", "") {
+			t.Fatalf("Expected ValidationException for FifoQueue=true without .fifo suffix, got %v", err)
+		}
+	})
+}
+
+// TestFifoQueue_OrderingAndBlocking checks in-order delivery within a group and
+// that the group is blocked while one of its messages is in flight.
+func TestFifoQueue_OrderingAndBlocking(t *testing.T) {
+	ctx := context.Background()
+	client, srv := makeClientServerPair()
+	defer srv.Shutdown(ctx)
+
+	queueUrl := createFifoQueue(t, ctx, client, "ordered.fifo")
+
+	bodies := []string{"first", "second", "third"}
+	for _, body := range bodies {
+		_, err := client.SendMessage(ctx, &sqs.SendMessageInput{
+			QueueUrl:       aws.String(queueUrl),
+			MessageBody:    aws.String(body),
+			MessageGroupId: aws.String("group1"),
+		})
+		if err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	for _, expectedBody := range bodies {
+		// The group yields only its next in-order message per receive.
+		receiveResp, err := client.ReceiveMessage(ctx, &sqs.ReceiveMessageInput{
+			QueueUrl:            aws.String(queueUrl),
+			MaxNumberOfMessages: 10,
+		})
+		if err != nil {
+			t.Fatal(err)
+		}
+		if len(receiveResp.Messages) != 1 {
+			t.Fatalf("Expected 1 in-order message, got %d", len(receiveResp.Messages))
+		}
+		if *receiveResp.Messages[0].Body != expectedBody {
+			t.Fatalf("Expected %q, got %q", expectedBody, *receiveResp.Messages[0].Body)
+		}
+
+		// Blocked until deleted: a second receive yields nothing.
+		blockedResp, err := client.ReceiveMessage(ctx, &sqs.ReceiveMessageInput{
+			QueueUrl:            aws.String(queueUrl),
+			MaxNumberOfMessages: 10,
+		})
+		if err != nil {
+			t.Fatal(err)
+		}
+		if len(blockedResp.Messages) != 0 {
+			t.Fatalf("Expected 0 messages while group is in flight, got %d", len(blockedResp.Messages))
+		}
+
+		_, err = client.DeleteMessage(ctx, &sqs.DeleteMessageInput{
+			QueueUrl:      aws.String(queueUrl),
+			ReceiptHandle: receiveResp.Messages[0].ReceiptHandle,
+		})
+		if err != nil {
+			t.Fatal(err)
+		}
+	}
+}
+
+// TestFifoQueue_Deduplication covers content-based and explicit dedup modes.
+func TestFifoQueue_Deduplication(t *testing.T) {
+	ctx := context.Background()
+	client, srv := makeClientServerPair()
+	defer srv.Shutdown(ctx)
+
+	t.Run("ContentBased", func(t *testing.T) {
+		queueUrl := createFifoQueue(t, ctx, client, "content-dedup.fifo")
+		for i := 0; i < 3; i++ {
+			_, err := client.SendMessage(ctx, &sqs.SendMessageInput{
+				QueueUrl:       aws.String(queueUrl),
+				MessageBody:    aws.String("duplicate body"),
+				MessageGroupId: aws.String("group1"),
+			})
+			if err != nil {
+				t.Fatal(err)
+			}
+		}
+
+		receiveResp, err := client.ReceiveMessage(ctx, &sqs.ReceiveMessageInput{
+			QueueUrl:            aws.String(queueUrl),
+			MaxNumberOfMessages: 10,
+		})
+		if err != nil {
+			t.Fatal(err)
+		}
+		if len(receiveResp.Messages) != 1 {
+			t.Fatalf("Expected 1 message after deduplication, got %d", len(receiveResp.Messages))
+		}
+	})
+
+	t.Run("ExplicitId", func(t *testing.T) {
+		queueUrl := createFifoQueueNoDedup(t, ctx, client, "explicit-dedup.fifo")
+
+		// Same dedup ID, different body: deduplicated, returns the first ID.
+		first, err := client.SendMessage(ctx, &sqs.SendMessageInput{
+			QueueUrl:               aws.String(queueUrl),
+			MessageBody:            aws.String("body-a"),
+			MessageGroupId:         aws.String("group1"),
+			MessageDeduplicationId: aws.String("dedup-1"),
+		})
+		if err != nil {
+			t.Fatal(err)
+		}
+		second, err := client.SendMessage(ctx, &sqs.SendMessageInput{
+			QueueUrl:               aws.String(queueUrl),
+			MessageBody:            aws.String("body-b"),
+			MessageGroupId:         aws.String("group1"),
+			MessageDeduplicationId: aws.String("dedup-1"),
+		})
+		if err != nil {
+			t.Fatal(err)
+		}
+		if aws.ToString(first.MessageId) == "" {
+			t.Fatal("Expected a MessageId on the first send")
+		}
+		if aws.ToString(second.MessageId) != aws.ToString(first.MessageId) {
+			t.Fatalf("Expected dedup hit to return original MessageId %q, got %q",
+				aws.ToString(first.MessageId), aws.ToString(second.MessageId))
+		}
+
+		// A different dedup ID is a distinct message.
+		_, err = client.SendMessage(ctx, &sqs.SendMessageInput{
+			QueueUrl:               aws.String(queueUrl),
+			MessageBody:            aws.String("body-c"),
+			MessageGroupId:         aws.String("group1"),
+			MessageDeduplicationId: aws.String("dedup-2"),
+		})
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		// Drain the queue, deleting as we go (one message per group per receive).
+		var bodies []string
+		for {
+			resp, err := client.ReceiveMessage(ctx, &sqs.ReceiveMessageInput{
+				QueueUrl:            aws.String(queueUrl),
+				MaxNumberOfMessages: 10,
+			})
+			if err != nil {
+				t.Fatal(err)
+			}
+			if len(resp.Messages) == 0 {
+				break
+			}
+			for _, m := range resp.Messages {
+				bodies = append(bodies, *m.Body)
+				_, err = client.DeleteMessage(ctx, &sqs.DeleteMessageInput{
+					QueueUrl:      aws.String(queueUrl),
+					ReceiptHandle: m.ReceiptHandle,
+				})
+				if err != nil {
+					t.Fatal(err)
+				}
+			}
+		}
+
+		if len(bodies) != 2 || bodies[0] != "body-a" || bodies[1] != "body-c" {
+			t.Fatalf("Expected [body-a body-c], got %v", bodies)
+		}
+	})
+}
+
+func TestFifoQueue_MessageGroupIsolation(t *testing.T) {
+	ctx := context.Background()
+	client, srv := makeClientServerPair()
+	defer srv.Shutdown(ctx)
+
+	queueUrl := createFifoQueue(t, ctx, client, "groups.fifo")
+
+	_, err := client.SendMessage(ctx, &sqs.SendMessageInput{
+		QueueUrl:       aws.String(queueUrl),
+		MessageBody:    aws.String("group-a msg1"),
+		MessageGroupId: aws.String("group-a"),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, err = client.SendMessage(ctx, &sqs.SendMessageInput{
+		QueueUrl:       aws.String(queueUrl),
+		MessageBody:    aws.String("group-b msg1"),
+		MessageGroupId: aws.String("group-b"),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Receive first message (from group-a, since it was sent first).
+	resp1, err := client.ReceiveMessage(ctx, &sqs.ReceiveMessageInput{
+		QueueUrl:            aws.String(queueUrl),
+		MaxNumberOfMessages: 1,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(resp1.Messages) != 1 {
+		t.Fatal("Expected 1 message")
+	}
+
+	// Without deleting group-a's message, we should still be able to receive
+	// group-b's message since groups are independent.
+	resp2, err := client.ReceiveMessage(ctx, &sqs.ReceiveMessageInput{
+		QueueUrl:            aws.String(queueUrl),
+		MaxNumberOfMessages: 1,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(resp2.Messages) != 1 {
+		t.Fatal("Expected 1 message from another group")
+	}
+	if *resp1.Messages[0].Body == *resp2.Messages[0].Body {
+		t.Fatal("Both receives returned the same message; groups are not isolated")
 	}
 }

--- a/services/sqs/itest/sqs_test.go
+++ b/services/sqs/itest/sqs_test.go
@@ -135,6 +135,61 @@ func TestSendReceiveMessage_RoundtripAttributes(t *testing.T) {
 	}
 }
 
+func TestReceiveMessageOutput_MultipleMessages(t *testing.T) {
+	ctx := context.Background()
+	client, srv := makeClientServerPair()
+	defer srv.Shutdown(ctx)
+
+	resp, err := client.CreateQueue(ctx, &sqs.CreateQueueInput{
+		QueueName: aws.String("queue"),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	bodies := []string{"message-1", "message-2", "message-3"}
+	for _, body := range bodies {
+		_, err = client.SendMessage(ctx, &sqs.SendMessageInput{
+			QueueUrl:    resp.QueueUrl,
+			MessageBody: aws.String(body),
+		})
+		if err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	receiveResp, err := client.ReceiveMessage(ctx, &sqs.ReceiveMessageInput{
+		QueueUrl:            resp.QueueUrl,
+		MaxNumberOfMessages: 10,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(receiveResp.Messages) != 3 {
+		t.Fatalf("Expected 3 messages, got %d", len(receiveResp.Messages))
+	}
+
+	var receivedBodies []string
+	for _, msg := range receiveResp.Messages {
+		if msg.Body == nil {
+			t.Fatal("Message body should not be nil")
+		}
+		if msg.MessageId == nil || *msg.MessageId == "" {
+			t.Fatal("Message should have a MessageId")
+		}
+		if msg.ReceiptHandle == nil || *msg.ReceiptHandle == "" {
+			t.Fatal("Message should have a ReceiptHandle")
+		}
+		receivedBodies = append(receivedBodies, *msg.Body)
+	}
+
+	slices.Sort(receivedBodies)
+	slices.Sort(bodies)
+	if !slices.Equal(receivedBodies, bodies) {
+		t.Fatalf("Expected bodies %v, got %v", bodies, receivedBodies)
+	}
+}
+
 func TestMessageVisibility(t *testing.T) {
 	ctx := context.Background()
 	client, srv := makeClientServerPair()

--- a/services/sqs/itest/sqs_test.go
+++ b/services/sqs/itest/sqs_test.go
@@ -323,10 +323,10 @@ func TestInitialQueues(t *testing.T) {
 func createFifoQueue(t *testing.T, ctx context.Context, client *sqs.Client, name string) string {
 	t.Helper()
 	resp, err := client.CreateQueue(ctx, &sqs.CreateQueueInput{
-		QueueName: aws.String(name),
+		QueueName: &name,
 		Attributes: map[string]string{
-			"FifoQueue":                 "true",
-			"ContentBasedDeduplication": "true",
+			sqsImpl.AttrFifoQueue:                 "true",
+			sqsImpl.AttrContentBasedDeduplication: "true",
 		},
 	})
 	if err != nil {
@@ -340,9 +340,9 @@ func createFifoQueue(t *testing.T, ctx context.Context, client *sqs.Client, name
 func createFifoQueueNoDedup(t *testing.T, ctx context.Context, client *sqs.Client, name string) string {
 	t.Helper()
 	resp, err := client.CreateQueue(ctx, &sqs.CreateQueueInput{
-		QueueName: aws.String(name),
+		QueueName: &name,
 		Attributes: map[string]string{
-			"FifoQueue": "true",
+			sqsImpl.AttrFifoQueue: "true",
 		},
 	})
 	if err != nil {
@@ -416,7 +416,7 @@ func TestFifoQueue_Validation(t *testing.T) {
 		_, err := client.CreateQueue(ctx, &sqs.CreateQueueInput{
 			QueueName: aws.String("not-fifo-named"),
 			Attributes: map[string]string{
-				"FifoQueue": "true",
+				sqsImpl.AttrFifoQueue: "true",
 			},
 		})
 		if !isErrorCode(err, "ValidationException", "") {

--- a/services/sqs/sqs.go
+++ b/services/sqs/sqs.go
@@ -3,6 +3,7 @@ package sqs
 import (
 	"bytes"
 	"crypto/md5"
+	"crypto/sha256"
 	"encoding/base64"
 	"encoding/hex"
 	"log/slog"
@@ -51,6 +52,16 @@ type Message struct {
 	Deleted      bool
 	VisibleAt    time.Time
 	DelayedUntil time.Time
+
+	GroupId         string
+	DeduplicationId string
+}
+
+const deduplicationWindow = 5 * time.Minute
+
+type deduplicationEntry struct {
+	Timestamp time.Time
+	MessageId string
 }
 
 type Queue struct {
@@ -58,15 +69,20 @@ type Queue struct {
 	CreationTimestamp int64
 	Attributes        map[string]string
 	URL               string
+	IsFifo            bool
 
 	// Mutable
 	Messages []*Message
 	Tags     map[string]string
 
 	// Attributes
-	VisibilityTimeout  time.Duration
-	MaximumMessageSize int
-	DelayDuration      time.Duration
+	VisibilityTimeout         time.Duration
+	MaximumMessageSize        int
+	DelayDuration             time.Duration
+	ContentBasedDeduplication bool
+
+	// FIFO state
+	DeduplicationIds map[string]deduplicationEntry
 }
 
 type SQS struct {
@@ -102,7 +118,7 @@ func (s *SQS) CreateQueue(input CreateQueueInput) (*CreateQueueOutput, *awserror
 	defer s.mu.Unlock()
 
 	if queue, ok := s.queuesByName[input.QueueName]; ok {
-		if maps.Equal(queue.Attributes, input.Attribute) {
+		if maps.Equal(queue.Attributes, input.Attributes) {
 			return &CreateQueueOutput{
 				QueueUrl: queue.URL,
 			}, nil
@@ -110,19 +126,29 @@ func (s *SQS) CreateQueue(input CreateQueueInput) (*CreateQueueOutput, *awserror
 		return nil, QueueNameExists("")
 	}
 
+	isFifo := strings.HasSuffix(input.QueueName, ".fifo")
+	if input.Attributes["FifoQueue"] == "true" && !isFifo {
+		return nil, ValidationException("FIFO queue name must end with .fifo")
+	}
+
 	url := s.getQueueUrl(input.QueueName)
 
 	queue := &Queue{
-		Attributes: input.Attribute,
-		Tags:       input.Tag,
+		Attributes: input.Attributes,
+		Tags:       input.Tags,
 		URL:        url,
+		IsFifo:     isFifo,
 
 		VisibilityTimeout:  defaultVisibilityTimeout,
 		MaximumMessageSize: defaultMaximumMessageSize,
 		DelayDuration:      defaultDelayDuration,
 	}
 
-	err := s.lockedSetQueueAttributes(queue, input.Attribute)
+	if isFifo {
+		queue.DeduplicationIds = make(map[string]deduplicationEntry)
+	}
+
+	err := s.lockedSetQueueAttributes(queue, input.Attributes)
 	if err != nil {
 		return nil, err
 	}
@@ -181,31 +207,75 @@ func (s *SQS) SendMessage(input SendMessageInput) (*SendMessageOutput, *awserror
 		return nil, ValidationException("Message too long")
 	}
 
+	if queue.IsFifo && input.MessageGroupId == "" {
+		return nil, MissingParameter("MessageGroupId is required for FIFO queues")
+	}
+
 	delayDuration := time.Duration(input.DelaySeconds)
 	if delayDuration == 0 {
 		delayDuration = queue.DelayDuration
 	}
 
 	now := time.Now()
-
 	MD5OfBody := hexMD5([]byte(input.MessageBody))
+	messageId := uuid.Must(uuid.NewV4())
+
+	var dedupId string
+	if queue.IsFifo {
+		dedupId = input.MessageDeduplicationId
+		if dedupId == "" && queue.ContentBasedDeduplication {
+			dedupId = hexSHA256([]byte(input.MessageBody))
+		}
+		if dedupId == "" {
+			return nil, MissingParameter("MessageDeduplicationId is required when ContentBasedDeduplication is disabled")
+		}
+
+		// Evict expired dedup entries, then check for duplicates.
+		for id, entry := range queue.DeduplicationIds {
+			if now.Sub(entry.Timestamp) > deduplicationWindow {
+				delete(queue.DeduplicationIds, id)
+			}
+		}
+		// On a dedup hit, return the original message's ID so callers can
+		// correlate it with the message they'll later receive.
+		if entry, exists := queue.DeduplicationIds[dedupId]; exists {
+			return &SendMessageOutput{
+				MD5OfMessageBody: MD5OfBody,
+				MessageId:        entry.MessageId,
+			}, nil
+		}
+
+		queue.DeduplicationIds[dedupId] = deduplicationEntry{
+			Timestamp: now,
+			MessageId: messageId.String(),
+		}
+	}
+
 	queue.Messages = append(queue.Messages, &Message{
-		UUID:                    uuid.Must(uuid.NewV4()),
+		UUID:                    messageId,
 		Body:                    input.MessageBody,
 		MD5OfBody:               MD5OfBody,
 		MessageAttributes:       input.MessageAttributes,
 		MessageSystemAttributes: input.MessageSystemAttributes,
 		VisibleAt:               now,
 		DelayedUntil:            now.Add(delayDuration),
+		GroupId:         input.MessageGroupId,
+		DeduplicationId: dedupId,
 	})
 
 	return &SendMessageOutput{
 		MD5OfMessageBody: MD5OfBody,
+		MessageId:        messageId.String(),
 	}, nil
 }
 
 func hexMD5(data []byte) string {
 	hash := md5.Sum(data)
+	return hex.EncodeToString(hash[:])
+}
+
+func hexSHA256(data []byte) string {
+	hash := sha256.Sum256(data)
 	return hex.EncodeToString(hash[:])
 }
 
@@ -334,6 +404,27 @@ func (s *SQS) ReceiveMessage(input ReceiveMessageInput) (*ReceiveMessageOutput, 
 		visibilityTimeout = queue.VisibilityTimeout
 	}
 
+	// A FIFO message group is "in flight" when one of its messages has been
+	// received but not yet deleted (its visibility timeout hasn't expired).
+	// We must not deliver any further message from such a group until the
+	// outstanding one is deleted or becomes visible again, otherwise ordering
+	// within the group would be violated.
+	var groupsInFlight map[string]bool
+	if queue.IsFifo {
+		groupsInFlight = make(map[string]bool)
+		for _, message := range queue.Messages {
+			if message.Deleted || message.GroupId == "" {
+				continue
+			}
+			// VisibleAt in the future means the message has been received and
+			// is still within its visibility timeout (an unreceived message
+			// keeps its send-time VisibleAt, which is in the past).
+			if message.VisibleAt.After(now) {
+				groupsInFlight[message.GroupId] = true
+			}
+		}
+	}
+
 	output := &ReceiveMessageOutput{}
 	for _, message := range queue.Messages {
 		if message.Deleted {
@@ -348,6 +439,10 @@ func (s *SQS) ReceiveMessage(input ReceiveMessageInput) (*ReceiveMessageOutput, 
 			continue
 		}
 
+		if queue.IsFifo && message.GroupId != "" && groupsInFlight[message.GroupId] {
+			continue
+		}
+
 		output.Message = append(output.Message, APIMessage{
 			Body:              message.Body,
 			MD5OfBody:         message.MD5OfBody,
@@ -359,6 +454,13 @@ func (s *SQS) ReceiveMessage(input ReceiveMessageInput) (*ReceiveMessageOutput, 
 		})
 
 		message.VisibleAt = now.Add(visibilityTimeout)
+
+		// Limitation: we deliver at most one message per group per call. Real
+		// SQS can return several ordered messages from the same group in a
+		// single ReceiveMessage; this is simpler and still preserves ordering.
+		if queue.IsFifo && message.GroupId != "" {
+			groupsInFlight[message.GroupId] = true
+		}
 
 		if len(output.Message) == input.MaxNumberOfMessages {
 			break
@@ -540,6 +642,8 @@ func (s *SQS) lockedSetQueueAttributes(queue *Queue, attributes map[string]strin
 			}
 
 			queue.DelayDuration = time.Duration(delay) * time.Second
+		} else if k == "ContentBasedDeduplication" {
+			queue.ContentBasedDeduplication = v == "true"
 		}
 	}
 

--- a/services/sqs/sqs.go
+++ b/services/sqs/sqs.go
@@ -6,6 +6,7 @@ import (
 	"crypto/sha256"
 	"encoding/base64"
 	"encoding/hex"
+	"unsafe"
 	"log/slog"
 	"maps"
 	"regexp"
@@ -21,6 +22,9 @@ import (
 )
 
 const (
+	AttrFifoQueue                 = "FifoQueue"
+	AttrContentBasedDeduplication = "ContentBasedDeduplication"
+
 	defaultVisibilityTimeout    = 30 * time.Second
 	maxVisibilityTimeoutSeconds = 12 * 3600
 
@@ -127,8 +131,12 @@ func (s *SQS) CreateQueue(input CreateQueueInput) (*CreateQueueOutput, *awserror
 	}
 
 	isFifo := strings.HasSuffix(input.QueueName, ".fifo")
-	if input.Attributes["FifoQueue"] == "true" && !isFifo {
+	fifoAttr := input.Attributes[AttrFifoQueue]
+	if fifoAttr == "true" && !isFifo {
 		return nil, ValidationException("FIFO queue name must end with .fifo")
+	}
+	if fifoAttr != "" && fifoAttr != "true" {
+		return nil, ValidationException("Invalid value for the parameter FifoQueue")
 	}
 
 	url := s.getQueueUrl(input.QueueName)
@@ -217,14 +225,14 @@ func (s *SQS) SendMessage(input SendMessageInput) (*SendMessageOutput, *awserror
 	}
 
 	now := time.Now()
-	MD5OfBody := hexMD5([]byte(input.MessageBody))
+	MD5OfBody := hexMD5(input.MessageBody)
 	messageId := uuid.Must(uuid.NewV4())
 
 	var dedupId string
 	if queue.IsFifo {
 		dedupId = input.MessageDeduplicationId
 		if dedupId == "" && queue.ContentBasedDeduplication {
-			dedupId = hexSHA256([]byte(input.MessageBody))
+			dedupId = hexSHA256(input.MessageBody)
 		}
 		if dedupId == "" {
 			return nil, MissingParameter("MessageDeduplicationId is required when ContentBasedDeduplication is disabled")
@@ -269,13 +277,17 @@ func (s *SQS) SendMessage(input SendMessageInput) (*SendMessageOutput, *awserror
 	}, nil
 }
 
-func hexMD5(data []byte) string {
-	hash := md5.Sum(data)
+func stringBytes(s string) []byte {
+	return unsafe.Slice(unsafe.StringData(s), len(s))
+}
+
+func hexMD5(s string) string {
+	hash := md5.Sum(stringBytes(s))
 	return hex.EncodeToString(hash[:])
 }
 
-func hexSHA256(data []byte) string {
-	hash := sha256.Sum256(data)
+func hexSHA256(s string) string {
+	hash := sha256.Sum256(stringBytes(s))
 	return hex.EncodeToString(hash[:])
 }
 
@@ -642,7 +654,7 @@ func (s *SQS) lockedSetQueueAttributes(queue *Queue, attributes map[string]strin
 			}
 
 			queue.DelayDuration = time.Duration(delay) * time.Second
-		} else if k == "ContentBasedDeduplication" {
+		} else if k == AttrContentBasedDeduplication {
 			queue.ContentBasedDeduplication = v == "true"
 		}
 	}

--- a/services/sqs/types.go
+++ b/services/sqs/types.go
@@ -3,9 +3,9 @@ package sqs
 import "encoding/xml"
 
 type CreateQueueInput struct {
-	Attribute map[string]string
-	QueueName string
-	Tag       map[string]string
+	Attributes map[string]string
+	QueueName  string
+	Tags       map[string]string
 }
 
 type CreateQueueOutput struct {


### PR DESCRIPTION
## Summary
Adds FIFO support with these features:

* FIFO queue creation: queues ending in .fifo are recognized as FIFO. Trying to set FifoQueue=true without the .fifo suffix is rejected.
* Message group ordering: every message sent to a FIFO queue must include a MessageGroupId. Messages within the same group are delivered in the exact order they were sent. Different groups are independent, so
one slow group doesn't block others.
* Deduplication: if the same message is sent twice within a 5-minute window, the duplicate is silently dropped. This works two ways: content-based (hashing the body) when the queue has ContentBasedDeduplication
enabled, or via an explicit MessageDeduplicationId the sender provides.
* In-flight blocking per group: once a message from a group is received but not yet deleted, no other messages from that same group are delivered. Deleting the message unblocks the group.

## Test Plan
Adds a few unit tests, I'll outline what each one does below:

* TestFifoQueue_CreateWithSuffix: Creates a FIFO queue with a .fifo name, verifies it shows up in ListQueues with the correct URL
* TestFifoQueue_Validation checks that the server rejects invalid FIFO requests with the right errors. It checks that the fifo queue has a message group id, content base deduplication, and that the the attribute for FifoQueue is true only if it has a .fifo suffix.
* TestFifoQueue_OrderingAndBlocking verifies two 3 messages are sent in order
* TestFifoQueue_Deduplication tests that duplicate messages are skipped
* TestFifoQueue_MessageGroupIsolation verifies that one blocked group doenst block the other group