### PR TITLE
[kms] Load persisted aliases on startup

### DIFF
--- a/services/kms/kms.go
+++ b/services/kms/kms.go
@@ -102,7 +102,7 @@ func New(options Options) (*KMS, error) {
 		logger:       options.Logger,
 		arnGenerator: options.ArnGenerator,
 		persistDir:   options.PersistDir,
-		aliases:      make(map[string]KeyId),
+		aliases:      aliases,
 		keys:         keys,
 	}, nil
 }

--- a/services/kms/kms_test.go
+++ b/services/kms/kms_test.go
@@ -421,3 +421,60 @@ func TestInvalidCiphertext(t *testing.T) {
 		t.Fatal("bad err", err)
 	}
 }
+
+func TestPersistedAliasesSurviveRestart(t *testing.T) {
+	options := kmsOptions
+	options.PersistDir = t.TempDir()
+
+	k, err := New(options)
+	if err != nil {
+		t.Fatal(err)
+	}
+	createOutput, awserr := k.CreateKey(CreateKeyInput{})
+	if awserr != nil {
+		t.Fatal(awserr)
+	}
+	keyId := createOutput.KeyMetadata.KeyId
+
+	aliasName := "alias/persisted"
+	_, awserr = k.CreateAlias(CreateAliasInput{
+		AliasName:   aliasName,
+		TargetKeyId: keyId,
+	})
+	if awserr != nil {
+		t.Fatal(awserr)
+	}
+
+	plaintext := []byte("The quick brown fox jumps over the lazy dog")
+	encryptOutput, awserr := k.Encrypt(EncryptInput{
+		KeyId:     aliasName,
+		Plaintext: plaintext,
+	})
+	if awserr != nil {
+		t.Fatal(awserr)
+	}
+
+	// Simulate a restart by building a fresh KMS from the same persist dir.
+	restarted, err := New(options)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	describeOutput, awserr := restarted.DescribeKey(DescribeKeyInput{KeyId: aliasName})
+	if awserr != nil {
+		t.Fatal(awserr)
+	}
+	if describeOutput.KeyMetadata.KeyId != keyId {
+		t.Fatalf("alias resolves to %v, want %v", describeOutput.KeyMetadata.KeyId, keyId)
+	}
+
+	decryptOutput, awserr := restarted.Decrypt(DecryptInput{
+		CiphertextBlob: encryptOutput.CiphertextBlob,
+	})
+	if awserr != nil {
+		t.Fatal(awserr)
+	}
+	if !bytes.Equal(plaintext, decryptOutput.Plaintext) {
+		t.Fatalf("bad decryption result; got %v, want %v", decryptOutput.Plaintext, plaintext)
+	}
+}


### PR DESCRIPTION
`New()` reads `aliases.json` from the persist dir into a local map, but then constructs the KMS struct with a fresh empty map — so alias persistence has been write-only since it was introduced: keys survive a restart while every alias silently vanishes (`DescribeKey`/`Encrypt` by alias return `NotFoundException` after a process restart, even though the binding is on disk).

Found this while running aws-in-a-box as the local KMS emulator for envelope encryption in dev — each restart appeared to "lose" the CMK alias, and our provisioning kept minting orphan keys in response.

Fix: wire the loaded map into the struct. Added `TestPersistedAliasesSurviveRestart` (mirrors the s3 `TestPersist` pattern: create key + alias + encrypt, rebuild `KMS` from the same persist dir, assert the alias resolves to the same key and the ciphertext still decrypts). The test fails with `NotFoundException` before the fix and passes after. `go test ./...`, `go vet`, and `gofmt` are clean.