### PR TITLE
fix(sqs): decode FIFO attributes and system attribute names over the query protocol

### DIFF
--- a/services/sqs/handler.go
+++ b/services/sqs/handler.go
@@ -92,7 +92,9 @@ func unmarshal(r *http.Request, target any) error {
 				if v == "" {
 					break
 				}
-				f.Set(reflect.Append(f, reflect.ValueOf(v)))
+				// Element may be a defined string type (e.g. []SystemAttributeName);
+				// a bare string isn't assignable under reflect.Append, so convert.
+				f.Set(reflect.Append(f, reflect.ValueOf(v).Convert(f.Type().Elem())))
 			}
 		case reflect.Map:
 			// Initialize the map and then read as many elements as we can.
@@ -107,7 +109,13 @@ func unmarshal(r *http.Request, target any) error {
 				// via RegisterHTTPHandlers; this path can be removed once no
 				// form-urlencoded clients remain.
 				case "Attribute", "Attributes", "Tag", "Tags":
-					mapKey := r.FormValue(fmt.Sprintf("%s.%d.Key", fieldSingular, i))
+					// The SQS query protocol encodes queue attributes as
+					// Attribute.N.Name/.Value but tags as Tag.N.Key/.Value.
+					subKey := "Name"
+					if fieldSingular == "Tag" {
+						subKey = "Key"
+					}
+					mapKey := r.FormValue(fmt.Sprintf("%s.%d.%s", fieldSingular, i, subKey))
 					mapValue := r.FormValue(fmt.Sprintf("%s.%d.Value", fieldSingular, i))
 					if mapKey == "" && mapValue == "" {
 						break EntriesLoop

--- a/services/sqs/itest/sqs_test.go
+++ b/services/sqs/itest/sqs_test.go
@@ -4,9 +4,11 @@ import (
 	"bytes"
 	"context"
 	"errors"
+	"io"
 	"log/slog"
 	"net"
 	"net/http"
+	"net/url"
 	"slices"
 	"strings"
 	"testing"
@@ -638,4 +640,88 @@ func TestFifoQueue_MessageGroupIsolation(t *testing.T) {
 	if *resp1.Messages[0].Body == *resp2.Messages[0].Body {
 		t.Fatal("Both receives returned the same message; groups are not isolated")
 	}
+}
+
+// startQueryProtocolServer starts an SQS emulator and returns its base URL.
+// Callers drive it with raw form-urlencoded (legacy query protocol) requests
+// rather than the JSON SDK used by the tests above.
+func startQueryProtocolServer(t *testing.T) string {
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	impl := sqsImpl.New(sqsImpl.Options{
+		ArnGenerator: arn.Generator{AwsAccountId: "123456789012", Region: "us-east-1"},
+	})
+	methodRegistry := make(map[string]http.HandlerFunc)
+	impl.RegisterHTTPHandlers(slog.Default(), methodRegistry)
+	srv := server.NewWithHandlerChain(
+		server.HandlerFuncFromRegistry(slog.Default(), methodRegistry),
+		sqsImpl.NewHandler(slog.Default(), impl),
+	)
+	go srv.Serve(listener)
+	t.Cleanup(func() { srv.Close() })
+	return "http://" + listener.Addr().String()
+}
+
+func postQuery(t *testing.T, baseURL string, form url.Values) string {
+	t.Helper()
+	// A decode panic aborts the connection mid-response, surfacing here as a
+	// transport error ("socket hang up") rather than an HTTP status.
+	resp, err := http.PostForm(baseURL, form)
+	if err != nil {
+		t.Fatalf("query-protocol request failed (server panic?): %v", err)
+	}
+	defer resp.Body.Close()
+	body, _ := io.ReadAll(resp.Body)
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", resp.StatusCode, body)
+	}
+	return string(body)
+}
+
+// Regression test for the legacy query/form-urlencoded protocol. The JSON SDK
+// tests above never exercise this decode path, so two crashes shipped:
+//   - FIFO CreateQueue: queue attributes arrive as Attribute.N.Name (tags use
+//     Tag.N.Key), but the decoder read .Key for both and panicked.
+//   - ReceiveMessage: AttributeNames is []SystemAttributeName, and appending a
+//     bare string to it via reflect panicked.
+func TestQueryProtocol_FifoAndSystemAttributes(t *testing.T) {
+	baseURL := startQueryProtocolServer(t)
+
+	postQuery(t, baseURL, url.Values{
+		"Action":            {"CreateQueue"},
+		"Version":           {"2012-11-05"},
+		"QueueName":         {"test-queue.fifo"},
+		"Attribute.1.Name":  {"FifoQueue"},
+		"Attribute.1.Value": {"true"},
+	})
+
+	postQuery(t, baseURL, url.Values{
+		"Action":                 {"SendMessage"},
+		"Version":                {"2012-11-05"},
+		"QueueUrl":               {"test-queue.fifo"},
+		"MessageBody":            {"hello"},
+		"MessageGroupId":         {"g1"},
+		"MessageDeduplicationId": {"d1"},
+	})
+
+	body := postQuery(t, baseURL, url.Values{
+		"Action":          {"ReceiveMessage"},
+		"Version":         {"2012-11-05"},
+		"QueueUrl":        {"test-queue.fifo"},
+		"AttributeName.1": {"All"},
+	})
+	if !strings.Contains(body, "hello") {
+		t.Fatalf("expected the sent message in the receive response, got: %s", body)
+	}
+
+	// Tags decode by Tag.N.Key (not .Name) and must keep working.
+	postQuery(t, baseURL, url.Values{
+		"Action":      {"CreateQueue"},
+		"Version":     {"2012-11-05"},
+		"QueueName":   {"tagged-queue"},
+		"Tag.1.Key":   {"team"},
+		"Tag.1.Value": {"infra"},
+	})
 }


### PR DESCRIPTION
On the legacy query protocol (form-urlencoded, e.g. the JS SDK's `AwsQueryProtocol`), two SQS calls panic the request goroutine → `socket hang up`. Both are decode bugs in `unmarshal()` in `services/sqs/handler.go` (`register()` panics on any unmarshal error).

**1. FIFO CreateQueue (or any queue with attributes).** Attributes are read as `Attribute.N.Key`, but the query protocol sends `Attribute.N.Name` / `.Value` — only tags use `.Key`. Empty key → `mismatched key/value?` → panic. Standard queues have no attributes, so only `*.fifo` fails. AWS shows both in one request: `Attribute.1.Name=...&Attribute.1.Value=...&Tag.Key=...&Tag.Value=...` ([CreateQueue query-protocol example](https://docs.aws.amazon.com/AWSSimpleQueueService/latest/APIReference/API_CreateQueue.html)).

**2. ReceiveMessage with `AttributeNames`.** It's `[]SystemAttributeName`; appending a bare `string` via reflect panics (*value of type string is not assignable to type SystemAttributeName*). `AttributeNames=["All"]` triggers it.

## Fix (`handler.go`)
- read attributes by `.Name`, tags by `.Key`
- convert slice elements to the field's element type before `reflect.Append`

## Test
Existing SQS itests only cover the JSON protocol, so this path was untested. Added a query-protocol test: raw form `CreateQueue` (FIFO) → `SendMessage` → `ReceiveMessage(All)` → tagged `CreateQueue`. Fails on `master` (`panic: CreateQueue: mismatched key/value?`), passes with the fix; `go test ./services/sqs/...` green.

`PurgeQueue` is still unimplemented — separate, not a crash.